### PR TITLE
Fix ironic template for rabbitmq. Invalid parameter rabbit_user

### DIFF
--- a/packstack/puppet/templates/ironic_rabbitmq.pp
+++ b/packstack/puppet/templates/ironic_rabbitmq.pp
@@ -20,7 +20,7 @@ class { '::ironic':
   rabbit_host         => hiera('CONFIG_AMQP_HOST_URL'),
   rabbit_port         => hiera('CONFIG_AMQP_CLIENTS_PORT'),
   rabbit_use_ssl      => hiera('CONFIG_AMQP_SSL_ENABLED'),
-  rabbit_user         => hiera('CONFIG_AMQP_AUTH_USER'),
+  rabbit_userid       => hiera('CONFIG_AMQP_AUTH_USER'),
   rabbit_password     => hiera('CONFIG_AMQP_AUTH_PASSWORD'),
   database_connection => "mysql://ironic:${ironic_rabbitmq_cfg_ironic_db_pw}@${ironic_rabbitmq_cfg_mariadb_host}/ironic",
   debug               => true,


### PR DESCRIPTION
Error occurred at during setup Ironic via packstack.
It seems that parameter "rabbit_user" was deprecated. Should be used rabbit_userid parameter.
Error message is following.

---------------------------------------------------------------------------------------------
ERROR : Error appeared during Puppet run: 192.168.122.129_ironic.pp
Error: Invalid parameter rabbit_user on Class[Ironic] at /var/tmp/packstack/b40b57fe799f443087ef0c22b05d28df/manifests/192.168.122.129_ironic.pp:16 on node osp6-aio.redhat.internal
You will find full trace in log /var/tmp/packstack/20150626-141552-IwiNCO/manifests/192.168.122.129_ironic.pp.log

[FILE] ==== /var/tmp/packstack/20150626-141552-IwiNCO/manifests/192.168.122.129_ironic.pp.log
ESC[1;31mError: Invalid parameter rabbit_user on Class[Ironic] at /var/tmp/packstack/b40b57fe799f443087ef0c22b05d28df/manifests/192.168.122.129_ironic.pp:16 on node osp6-aio.redhat.internal
Wrapped exception:
Invalid parameter rabbit_userESC[0m
ESC[1;31mError: Invalid parameter rabbit_user on Class[Ironic] at /var/tmp/packstack/b40b57fe799f443087ef0c22b05d28df/manifests/192.168.122.129_ironic.pp:16 on node osp6-aio.redhat.internalESC[0m

Signed-off-by: Hajime Taira <htaira@redhat.com>